### PR TITLE
Use correct preprocessor defines for XLEN, FLEN, & RVV ELEN

### DIFF
--- a/bench/mandelbrot.c
+++ b/bench/mandelbrot.c
@@ -23,7 +23,7 @@ mandelbrot_scalar_f32(size_t width, size_t maxIter, uint32_t *res)
 	}
 }
 
-#if __riscv_xlen != 32
+#if defined (__riscv_flen) && __riscv_flen == 64
 void
 mandelbrot_scalar_f64(size_t width, size_t maxIter, uint32_t *res)
 {
@@ -56,12 +56,12 @@ mandelbrot_scalar_f64(size_t width, size_t maxIter, uint32_t *res)
 
 #define IMPLS(f) \
 	f(scalar_f32) \
-	IF64(f(scalar_f64)) \
+	IF_F64(f(scalar_f64)) \
 	IMPLS_F16(f) \
 	f(rvv_f32_m1) \
 	f(rvv_f32_m2) \
-	IF64(f(rvv_f64_m1)) \
-	IF64(f(rvv_f64_m2)) \
+	IF_VF64(f(rvv_f64_m1)) \
+	IF_VF64(f(rvv_f64_m2)) \
 
 typedef void Func(size_t width, size_t maxIter, uint32_t *res);
 

--- a/instructions/rvv/gen.S
+++ b/instructions/rvv/gen.S
@@ -13,6 +13,18 @@
 #define sx sd
 #endif
 
+#if defined (__riscv_flen) && __riscv_flen == 64
+#define IF_F64(...) __VA_ARGS__
+#else
+#define IF_F64(...)
+#endif
+
+#if defined (__riscv_v_elen_fp) && __riscv_v_elen_fp == 64
+#define IF_VF64(...) __VA_ARGS__
+#else
+#define IF_VF64(...)
+#endif
+
 #include "config.h"
 
 changecom(`#', `')

--- a/instructions/scalar/main.S
+++ b/instructions/scalar/main.S
@@ -10,6 +10,18 @@
 #define sx sd
 #endif
 
+#if defined (__riscv_flen) && __riscv_flen == 64
+#define IF_F64(...) __VA_ARGS__
+#else
+#define IF_F64(...)
+#endif
+
+#if defined (__riscv_v_elen_fp) && __riscv_v_elen_fp == 64
+#define IF_VF64(...) __VA_ARGS__
+#else
+#define IF_VF64(...)
+#endif
+
 .macro m_nop
 .endm
 

--- a/nolibc.h
+++ b/nolibc.h
@@ -16,6 +16,18 @@ typedef double fx;
 #define IF64(...) __VA_ARGS__
 #endif
 
+#if defined (__riscv_flen) && __riscv_flen == 64
+#define IF_F64(...) __VA_ARGS__
+#else
+#define IF_F64(...)
+#endif
+
+#if defined (__riscv_v_elen_fp) && __riscv_v_elen_fp == 64
+#define IF_VF64(...) __VA_ARGS__
+#else
+#define IF_VF64(...)
+#endif
+
 
 static void print_flush(void);
 


### PR DESCRIPTION
Hi, thanks a lot for these nice RISC-V V benchmarks.

I noticed that the mandelbrot app assumes that an XLEN of 64 implies an FLEN of 64 as well, and also that the vector extension supports 64 bit elements. However, that is not necessarily the case, as it is perfectly legal to have a RV64I base ISA with F extension but no D (32-bit floating-point only) and Zve32f vector extension, for instance.

This PR proposes adding `IF_F64` and `IF_VF64` macros in addition to the existing `IF64` macro, to conditionally enable/disable code based on the actual FLEN and ELEN configuration of the target.