### PR TITLE
vl must be a multiple of EGS

### DIFF
--- a/instructions/rvv/main.c
+++ b/instructions/rvv/main.c
@@ -30,6 +30,9 @@ run_all_types(char const *name, ux bIdx, ux vl, int ta, int ma)
 
 	ux lmuls[] = { 5, 6, 7, 0, 1, 2, 3 };
 
+	if (mask == T_GSH || mask == T_AES || mask == T_AES2 || mask == T_SHA)
+		vl = 4;
+
 	for (ux sew = 0; sew < 4; ++sew)
 	for (ux lmul_idx = 0; lmul_idx < 7; ++lmul_idx) {
 		ux lmul = lmuls[lmul_idx];


### PR DESCRIPTION
Some of the crypto instructions have constraints on vl. From the ISA:

    Since vl and vstart refer to elements, Vector Crypto instructions that use
    elements groups (See Section 32.1.4) require that these values are an integer
    multiple of the Element Group Size (EGS). Instructions that violate the vl
    or vstart requirements are reserved.